### PR TITLE
http://maps.googleapis.com/ -> https://maps.googleapis.com/

### DIFF
--- a/app/assets/javascripts/acts_as_mappable.js.erb
+++ b/app/assets/javascripts/acts_as_mappable.js.erb
@@ -26,7 +26,7 @@
 	loadApi: function() {
 	    var script = document.createElement("script");
 	    script.type = "text/javascript";
-	    src = "http://maps.googleapis.com/maps/api/js?sensor=false&callback=actsAsMappable.initToMap";
+	    src = "https://maps.googleapis.com/maps/api/js?sensor=false&callback=actsAsMappable.initToMap";
 	    if (actsAsMappable.apiKey !== "") {
 	        src = src + "&key=" + actsAsMappable.apiKey;
 	    }

--- a/lib/acts_as_mappable/version.rb
+++ b/lib/acts_as_mappable/version.rb
@@ -1,3 +1,3 @@
 module ActsAsMappable
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
To fix following error with medusa over HTTPS.
`Blocked loading mixed active content “http://maps.googleapis.com/maps/api/js?sensor=false&callback=actsAsMappable.initToMap”`